### PR TITLE
Rename dontNotifyIfEqual to notifyIfEqual

### DIFF
--- a/lib/src/list_notifier.dart
+++ b/lib/src/list_notifier.dart
@@ -5,7 +5,7 @@ import 'package:flutter/foundation.dart' show ChangeNotifier, ValueListenable;
 
 /// A List that behaves like `ValueNotifier` if its data changes.
 /// it does not compare the elements on bulk operations
-/// If you set [dontNotifyIfEqual] to `true` it will compare if a value passed value
+/// If you set [notifyIfEqual] to `false` it will compare if a value passed value
 ///  passed is equal to the existing value.
 /// like `list[5]=4` if the content at index 4 is equal to 4 and only call
 /// `notifyListeners` if they are not equal.
@@ -15,20 +15,20 @@ class ListNotifier<T> extends DelegatingList<T> with ChangeNotifier
   ///
   /// Creates a new listenable List
   /// [data] optional list that should be used as initial value
-  /// if  [dontNotifyIfEqual]  is `true` `ListNotifier` will compare if a value
+  /// if  [notifyIfEqual]  is `false` `ListNotifier` will compare if a value
   ///  passed is equal to the existing value.
   /// like `list[5]=4` if the content at index 4 is equal to 4 and only call
   /// `notifyListeners` if they are not equal. To prevent users from wondering
   /// why their UI doesn't update if they haven't overritten the equality operator
-  /// the default is `false`.
+  /// the default is `true`.
   /// Alternatively you can pass in a [customEquality] function that is then used instead
   /// of `==`
   ListNotifier(
-      {List<T> data, bool dontNotifyIfEqual = false, this.customEquality})
-      : _dontNotifyIfEqual = dontNotifyIfEqual,
+      {List<T> data, bool notifyIfEqual = true, this.customEquality})
+      : _notifyIfEqual = notifyIfEqual,
         super(data ?? []);
 
-  final bool _dontNotifyIfEqual;
+  final bool _notifyIfEqual;
   final bool Function(T x, T y) customEquality;
 
 
@@ -90,7 +90,7 @@ class ListNotifier<T> extends DelegatingList<T> with ChangeNotifier
         : super[index] == value;
     super[index] = value;
 
-    if ((!_dontNotifyIfEqual && customEquality == null) || !areEqual) {
+    if ((_notifyIfEqual && customEquality == null) || !areEqual) {
       _notify();
     }
   }

--- a/test/list_notifier_test.dart
+++ b/test/list_notifier_test.dart
@@ -176,7 +176,7 @@ void main() {
     test("The listener isn't notified if the value is equal", () {
       final ListNotifier list = ListNotifier(
         data: [1, 2, 3],
-        dontNotifyIfEqual: true,
+        notifyIfEqual: false,
       );
 
       list.addListener(() {
@@ -191,7 +191,7 @@ void main() {
     test("customEuqality works correctly", () {
       final ListNotifier list = ListNotifier(
         data: [1, 2, 3],
-        dontNotifyIfEqual: true,
+        notifyIfEqual: false,
         customEquality: (index, value) => value >= 3,
       );
 


### PR DESCRIPTION
Since `dontNotifyIfEqual` is a boolean variable, it would make more sense for it to named such that it seemingly does _not_ represent a value which is its inverse.
For example, in the following code snippet,
https://github.com/escamoteur/listenable_collections/blob/59d1eeb31da34f93b801332d33e14ad889f09c52/lib/src/list_notifier.dart#L93-L95

It would be mush easier to comprehend expressions like above if it is named as **`notifyIfEqual`**, and the default values changed accordingly.

### Checks
All tests are passing.